### PR TITLE
Fix database setup: add setup-db command and fix browse infinite loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,32 @@ For the web interface:
 pip install -e ".[web]"
 ```
 
+## Database setup
+
+ViroForge requires a local SQLite database of viral genomes (~500 MB). This is not included in the repository and must be built from NCBI RefSeq:
+
+```bash
+# Step 1: Download RefSeq viral genomes (may take a while)
+python scripts/download_refseq.py --output data/refseq --all
+
+# Step 2: Parse downloaded genomes
+python scripts/parse_genomes.py --input data/refseq --output data/parsed
+
+# Step 3: Create and populate the database
+python scripts/populate_database.py \
+    --input data/parsed \
+    --database viroforge/data/viral_genomes.db \
+    --create-db
+```
+
+Optionally, map ICTV taxonomy to improve family-level classification:
+
+```bash
+python scripts/parse_ictv_taxonomy.py \
+    --vmr data/ictv/VMR_current.xlsx \
+    --database viroforge/data/viral_genomes.db
+```
+
 ## Quick start
 
 ### Browse available collections

--- a/README.md
+++ b/README.md
@@ -34,28 +34,31 @@ pip install -e ".[web]"
 
 ## Database setup
 
-ViroForge requires a local SQLite database of viral genomes (~500 MB). This is not included in the repository and must be built from NCBI RefSeq:
+ViroForge requires a local SQLite database of viral genomes (~500 MB). This is not included in the repository and must be built from NCBI RefSeq. A single command handles everything — downloading genomes, parsing, building the database, and adding ICTV taxonomy:
 
 ```bash
-# Step 1: Download RefSeq viral genomes (may take a while)
-python scripts/download_refseq.py --output data/refseq --all
-
-# Step 2: Parse downloaded genomes
-python scripts/parse_genomes.py --input data/refseq --output data/parsed
-
-# Step 3: Create and populate the database
-python scripts/populate_database.py \
-    --input data/parsed \
-    --database viroforge/data/viral_genomes.db \
-    --create-db
+viroforge setup-db
 ```
 
-Optionally, map ICTV taxonomy to improve family-level classification:
+This will take a while on first run (RefSeq download + database build). Once complete, all ViroForge commands will work.
+
+### Troubleshooting options
+
+These flags are **only needed if something goes wrong** — most users should just run `viroforge setup-db` above.
 
 ```bash
-python scripts/parse_ictv_taxonomy.py \
-    --vmr data/ictv/VMR_current.xlsx \
-    --database viroforge/data/viral_genomes.db
+# Network failed partway through? Skip the RefSeq download and retry
+# the remaining steps using data that already downloaded successfully.
+viroforge setup-db --skip-download
+
+# ICTV website down or VMR download failing? Build a working database
+# without taxonomy. Genomes will have family='Unknown' more often,
+# but everything else works fine. You can add taxonomy later.
+viroforge setup-db --skip-taxonomy
+
+# Corrupted download, or ICTV released a new VMR version?
+# Force re-download of all files even if they already exist on disk.
+viroforge setup-db --force
 ```
 
 ## Quick start

--- a/viroforge/cli/__init__.py
+++ b/viroforge/cli/__init__.py
@@ -303,6 +303,35 @@ For more information: https://github.com/hecatomb/viroforge
     )
 
     # ========================================================================
+    # SETUP-DB command
+    # ========================================================================
+    setup_db_parser = subparsers.add_parser(
+        'setup-db',
+        help='Download data and build the local genome database',
+        description='Download RefSeq genomes, ICTV taxonomy, and build the SQLite database'
+    )
+    setup_db_parser.add_argument(
+        '--download-only',
+        action='store_true',
+        help='Only download raw data, do not build database'
+    )
+    setup_db_parser.add_argument(
+        '--skip-download',
+        action='store_true',
+        help='Skip RefSeq download (use existing data)'
+    )
+    setup_db_parser.add_argument(
+        '--skip-taxonomy',
+        action='store_true',
+        help='Skip ICTV taxonomy step'
+    )
+    setup_db_parser.add_argument(
+        '--force',
+        action='store_true',
+        help='Re-download files even if they already exist'
+    )
+
+    # ========================================================================
     # SUMMARY command
     # ========================================================================
     summary_parser = subparsers.add_parser(
@@ -362,6 +391,9 @@ For more information: https://github.com/hecatomb/viroforge
         elif args.command == 'web':
             from .web import run_web
             return run_web(args)
+        elif args.command == 'setup-db':
+            from .setup_db import run_setup_db
+            return run_setup_db(args)
         elif args.command == 'summary':
             from .summary import run_summary
             return run_summary(args)

--- a/viroforge/cli/__init__.py
+++ b/viroforge/cli/__init__.py
@@ -326,6 +326,11 @@ For more information: https://github.com/hecatomb/viroforge
         help='Skip ICTV taxonomy step'
     )
     setup_db_parser.add_argument(
+        '--skip-collections',
+        action='store_true',
+        help='Skip collection curation step'
+    )
+    setup_db_parser.add_argument(
         '--force',
         action='store_true',
         help='Re-download files even if they already exist'

--- a/viroforge/cli/browse.py
+++ b/viroforge/cli/browse.py
@@ -28,6 +28,7 @@ except ImportError:
     sys.exit(1)
 
 from .db_utils import (
+    get_database_path,
     load_all_collections,
     load_collection_details,
     search_collections,
@@ -195,6 +196,25 @@ def show_collection_details(collection_id: int, icons: bool = True):
 
 def run_browser(args):
     """Main browser loop."""
+    # Check for database before entering the loop
+    try:
+        get_database_path()
+    except FileNotFoundError:
+        console.print(
+            "\n[cyan]The viral genome database has not been set up yet. "
+            "Build it with:[/cyan]\n"
+        )
+        console.print("  python scripts/download_refseq.py --output data/refseq --all")
+        console.print("  python scripts/parse_genomes.py --input data/refseq --output data/parsed")
+        console.print(
+            "  python scripts/populate_database.py "
+            "--input data/parsed "
+            "--database viroforge/data/viral_genomes.db "
+            "--create-db"
+        )
+        console.print()
+        return 1
+
     icons = not args.no_icons
     search_query = ""
 

--- a/viroforge/cli/setup_db.py
+++ b/viroforge/cli/setup_db.py
@@ -5,9 +5,10 @@ ViroForge database setup command.
 Downloads required data files and builds the local database.
 
 Usage:
-    viroforge setup-db                    # Full setup (download + build + taxonomy)
+    viroforge setup-db                    # Full setup (download + build + taxonomy + collections)
     viroforge setup-db --download-only    # Only download raw data
     viroforge setup-db --skip-taxonomy    # Build database without ICTV taxonomy
+    viroforge setup-db --skip-collections # Build database without curating collections
 
 Author: ViroForge Development Team
 """
@@ -76,7 +77,7 @@ def run_setup_db(args) -> int:
 
     # Step 1: Download RefSeq viral genomes
     if not args.skip_download:
-        print("\n[Step 1/4] Downloading RefSeq viral genomes...")
+        print("\n[Step 1/5] Downloading RefSeq viral genomes...")
         refseq_dir = data_dir / "refseq"
         if refseq_dir.exists() and any(refseq_dir.iterdir()):
             print(f"  RefSeq data already exists at {refseq_dir}, skipping download.")
@@ -88,11 +89,11 @@ def run_setup_db(args) -> int:
         else:
             _run_script(project_root, "scripts/download_refseq.py", ["--output", str(refseq_dir)])
     else:
-        print("\n[Step 1/4] Skipping RefSeq download (--download-only not needed)")
+        print("\n[Step 1/5] Skipping RefSeq download (--download-only not needed)")
 
     # Step 2: Parse genomes
     if not args.download_only:
-        print("\n[Step 2/4] Parsing downloaded genomes...")
+        print("\n[Step 2/5] Parsing downloaded genomes...")
         refseq_dir = data_dir / "refseq"
         parsed_dir = data_dir / "parsed"
         if not refseq_dir.exists():
@@ -104,19 +105,19 @@ def run_setup_db(args) -> int:
         ])
 
         # Step 3: Create and populate database
-        print("\n[Step 3/4] Creating and populating database...")
+        print("\n[Step 3/5] Creating and populating database...")
         _run_script(project_root, "scripts/populate_database.py", [
             "--input", str(parsed_dir),
             "--database", str(db_path),
             "--create-db",
         ])
     else:
-        print("\n[Step 2/4] Skipping parse (--download-only)")
-        print("[Step 3/4] Skipping database creation (--download-only)")
+        print("\n[Step 2/5] Skipping parse (--download-only)")
+        print("[Step 3/5] Skipping database creation (--download-only)")
 
     # Step 4: Download ICTV VMR and add taxonomy
     if not args.skip_taxonomy and not args.download_only:
-        print("\n[Step 4/4] Adding ICTV taxonomy...")
+        print("\n[Step 4/5] Adding ICTV taxonomy...")
 
         # Download VMR if not present
         if vmr_path.exists() and not args.force:
@@ -136,7 +137,52 @@ def run_setup_db(args) -> int:
             "--update-db",
         ])
     else:
-        print("\n[Step 4/4] Skipping ICTV taxonomy")
+        print("\n[Step 4/5] Skipping ICTV taxonomy")
+
+    # Step 5: Curate collections
+    if not args.skip_collections and not args.download_only:
+        print("\n[Step 5/5] Curating genome collections...")
+
+        if not db_path.exists():
+            print("  ERROR: Database not found. Cannot curate collections without database.")
+            return 1
+
+        # Main body site collections (1-8)
+        _run_script(project_root, "scripts/curate_body_site_collections.py", [
+            "--all", "--database", str(db_path),
+        ])
+
+        # Additional collections (17-28) — each script has its own hardcoded DB path
+        # but they all default to viroforge/data/viral_genomes.db
+        additional_scripts = [
+            "scripts/curate_wastewater_collection.py",
+            "scripts/curate_ibd_gut_collection.py",
+            "scripts/curate_hiv_gut_collection.py",
+            "scripts/curate_cf_respiratory_collection.py",
+            "scripts/curate_respiratory_rna_collection.py",
+            "scripts/curate_arbovirus_mosquito_collection.py",
+            "scripts/curate_fecal_rna_collection.py",
+            "scripts/curate_vaginal_virome_collection.py",
+            "scripts/curate_blood_virome_collection.py",
+            "scripts/curate_ocular_virome_collection.py",
+            "scripts/curate_lung_virome_collection.py",
+            "scripts/curate_urinary_virome_collection.py",
+        ]
+
+        failed = []
+        for script in additional_scripts:
+            try:
+                _run_script(project_root, script, [])
+            except RuntimeError as e:
+                failed.append(script)
+                print(f"  WARNING: {script} failed: {e}")
+
+        if failed:
+            print(f"\n  {len(failed)} curation script(s) failed (see warnings above).")
+        else:
+            print(f"\n  All collection curation scripts completed successfully.")
+    else:
+        print("\n[Step 5/5] Skipping collection curation")
 
     print("\n" + "=" * 60)
     if db_path.exists():

--- a/viroforge/cli/setup_db.py
+++ b/viroforge/cli/setup_db.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+ViroForge database setup command.
+
+Downloads required data files and builds the local database.
+
+Usage:
+    viroforge setup-db                    # Full setup (download + build + taxonomy)
+    viroforge setup-db --download-only    # Only download raw data
+    viroforge setup-db --skip-taxonomy    # Build database without ICTV taxonomy
+
+Author: ViroForge Development Team
+"""
+
+import logging
+import sys
+import urllib.request
+import shutil
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ICTV VMR download URL (MSL40 - matches parse_ictv_taxonomy.py sheet name)
+ICTV_VMR_URL = "https://ictv.global/sites/default/files/VMR/VMR_MSL40.v2.20260223.xlsx"
+ICTV_VMR_FILENAME = "VMR_current.xlsx"
+
+
+def download_with_progress(url: str, dest: Path, label: str = "Downloading") -> None:
+    """Download a file with a progress indicator."""
+    print(f"{label}: {url}")
+    print(f"  -> {dest}")
+
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "ViroForge/0.12.0"})
+        with urllib.request.urlopen(req) as response:
+            total = response.getheader("Content-Length")
+            total = int(total) if total else None
+
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            downloaded = 0
+            block_size = 8192
+
+            with open(dest, "wb") as f:
+                while True:
+                    chunk = response.read(block_size)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+                    downloaded += len(chunk)
+                    if total:
+                        pct = downloaded * 100 // total
+                        mb = downloaded / (1024 * 1024)
+                        total_mb = total / (1024 * 1024)
+                        print(f"\r  {mb:.1f}/{total_mb:.1f} MB ({pct}%)", end="", flush=True)
+                    else:
+                        mb = downloaded / (1024 * 1024)
+                        print(f"\r  {mb:.1f} MB downloaded", end="", flush=True)
+            print()  # newline after progress
+    except Exception as e:
+        if dest.exists():
+            dest.unlink()
+        raise RuntimeError(f"Download failed: {e}") from e
+
+
+def run_setup_db(args) -> int:
+    """Run the database setup process."""
+    project_root = Path(__file__).parent.parent.parent
+    data_dir = project_root / "data"
+    ictv_dir = data_dir / "ictv"
+    db_path = project_root / "viroforge" / "data" / "viral_genomes.db"
+    vmr_path = ictv_dir / ICTV_VMR_FILENAME
+
+    print("=" * 60)
+    print("ViroForge Database Setup")
+    print("=" * 60)
+
+    # Step 1: Download RefSeq viral genomes
+    if not args.skip_download:
+        print("\n[Step 1/4] Downloading RefSeq viral genomes...")
+        refseq_dir = data_dir / "refseq"
+        if refseq_dir.exists() and any(refseq_dir.iterdir()):
+            print(f"  RefSeq data already exists at {refseq_dir}, skipping download.")
+            print("  (Use --force to re-download)")
+            if not args.force:
+                pass  # skip
+            else:
+                _run_script(project_root, "scripts/download_refseq.py", ["--output", str(refseq_dir)])
+        else:
+            _run_script(project_root, "scripts/download_refseq.py", ["--output", str(refseq_dir)])
+    else:
+        print("\n[Step 1/4] Skipping RefSeq download (--download-only not needed)")
+
+    # Step 2: Parse genomes
+    if not args.download_only:
+        print("\n[Step 2/4] Parsing downloaded genomes...")
+        refseq_dir = data_dir / "refseq"
+        parsed_dir = data_dir / "parsed"
+        if not refseq_dir.exists():
+            print("  ERROR: RefSeq data not found. Run without --skip-download first.")
+            return 1
+        _run_script(project_root, "scripts/parse_genomes.py", [
+            "--input", str(refseq_dir),
+            "--output", str(parsed_dir),
+        ])
+
+        # Step 3: Create and populate database
+        print("\n[Step 3/4] Creating and populating database...")
+        _run_script(project_root, "scripts/populate_database.py", [
+            "--input", str(parsed_dir),
+            "--database", str(db_path),
+            "--create-db",
+        ])
+    else:
+        print("\n[Step 2/4] Skipping parse (--download-only)")
+        print("[Step 3/4] Skipping database creation (--download-only)")
+
+    # Step 4: Download ICTV VMR and add taxonomy
+    if not args.skip_taxonomy and not args.download_only:
+        print("\n[Step 4/4] Adding ICTV taxonomy...")
+
+        # Download VMR if not present
+        if vmr_path.exists() and not args.force:
+            print(f"  VMR file already exists at {vmr_path}, skipping download.")
+        else:
+            print("  Downloading ICTV Virus Metadata Resource (VMR)...")
+            download_with_progress(ICTV_VMR_URL, vmr_path, label="  Fetching VMR")
+
+        if not db_path.exists():
+            print("  ERROR: Database not found. Cannot add taxonomy without database.")
+            return 1
+
+        _run_script(project_root, "scripts/parse_ictv_taxonomy.py", [
+            "--vmr", str(vmr_path),
+            "--output", str(ictv_dir),
+            "--database", str(db_path),
+            "--update-db",
+        ])
+    else:
+        print("\n[Step 4/4] Skipping ICTV taxonomy")
+
+    print("\n" + "=" * 60)
+    if db_path.exists():
+        size_mb = db_path.stat().st_size / (1024 * 1024)
+        print(f"Database ready: {db_path} ({size_mb:.0f} MB)")
+    print("Setup complete! You can now run: viroforge browse")
+    print("=" * 60)
+
+    return 0
+
+
+def _run_script(project_root: Path, script: str, extra_args: list) -> None:
+    """Run a Python script as a subprocess."""
+    import subprocess
+    cmd = [sys.executable, str(project_root / script)] + extra_args
+    print(f"  Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, cwd=str(project_root))
+    if result.returncode != 0:
+        raise RuntimeError(f"Script failed with exit code {result.returncode}: {script}")


### PR DESCRIPTION
## Summary

- **Add `viroforge setup-db` CLI command** that automates the entire database setup process — downloads RefSeq genomes, parses them, builds the SQLite database, and downloads + applies ICTV taxonomy. Replaces the previous manual 4-step process with a single command.
- **Update README database setup section** to use the new `setup-db` command, with clearly documented troubleshooting flags (`--skip-download`, `--skip-taxonomy`, `--force`) for edge cases like network failures or ICTV downtime.
- **Fix infinite error loop in `viroforge browse`** when the database is missing. Previously, the missing database error was caught inside the main `while True` loop, causing "Press Enter to continue..." to repeat forever. Now the database is checked before entering the loop, and a friendly message with setup instructions is shown before exiting cleanly.

Closes #2, Closes #3

## Changes

- `viroforge/cli/setup_db.py` — New module implementing the `setup-db` command with automatic ICTV VMR download
- `viroforge/cli/__init__.py` — Register `setup-db` subcommand and route to handler
- `README.md` — Replace manual 4-step setup with `viroforge setup-db`

## Test plan

- [ ] Clone repo fresh, `pip install -e .`, run `viroforge browse` without building the database — should show setup instructions and exit cleanly
- [ ] Run `viroforge setup-db --help` — should show all options
- [ ] Run `viroforge setup-db` — should download RefSeq, build database, download ICTV VMR, and apply taxonomy
- [ ] Run `viroforge setup-db --skip-download` — should skip RefSeq download and only add taxonomy
- [ ] Verify `viroforge browse` works after database setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)