### PR TITLE
feat: add VLP filtration pore size selection (0.1, 0.2, 0.45 um + custom)

### DIFF
--- a/scripts/generate_fastq_dataset.py
+++ b/scripts/generate_fastq_dataset.py
@@ -460,18 +460,25 @@ class FASTQGenerator:
         # Map protocol name to VLPProtocol
         protocol_map = {
             'tangential_flow': VLPProtocol.tangential_flow_standard(),
+            'tangential_flow_045': VLPProtocol.tangential_flow_045(),
+            'tangential_flow_01': VLPProtocol.tangential_flow_01(),
             'syringe': VLPProtocol.syringe_filter_standard(),
+            'syringe_045': VLPProtocol.syringe_filter_045(),
             'ultracentrifugation': VLPProtocol.ultracentrifugation(),
             'norgen': VLPProtocol.norgen_kit()
         }
 
-        if vlp_protocol not in protocol_map:
+        # Check for dynamically registered custom pore size configs
+        custom_configs = getattr(self, '_custom_vlp_configs', {})
+        if vlp_protocol in custom_configs:
+            protocol_config = custom_configs[vlp_protocol]
+        elif vlp_protocol not in protocol_map:
             raise ValueError(
                 f"Unknown VLP protocol: {vlp_protocol}. "
                 f"Choose from: {', '.join(protocol_map.keys())}"
             )
-
-        protocol_config = protocol_map[vlp_protocol]
+        else:
+            protocol_config = protocol_map[vlp_protocol]
 
         # Initialize VLP enrichment
         vlp = VLPEnrichment(
@@ -1279,9 +1286,25 @@ Examples:
 
     parser.add_argument(
         '--vlp-protocol',
-        choices=['tangential_flow', 'syringe', 'ultracentrifugation', 'norgen'],
+        choices=['tangential_flow', 'tangential_flow_045', 'tangential_flow_01',
+                 'syringe', 'syringe_045',
+                 'ultracentrifugation', 'norgen'],
         default='tangential_flow',
-        help='VLP enrichment protocol (default: tangential_flow)'
+        help='VLP enrichment protocol (default: tangential_flow). '
+             'Filtration pore sizes: tangential_flow=0.2um, '
+             'tangential_flow_045=0.45um (giant viruses), '
+             'tangential_flow_01=0.1um (tight, phage-focused), '
+             'syringe=0.2um, syringe_045=0.45um. '
+             'Or use --pore-size for custom values.'
+    )
+
+    parser.add_argument(
+        '--pore-size',
+        type=float,
+        default=None,
+        help='Custom filtration pore size in micrometers (overrides protocol default). '
+             'Common values: 0.1, 0.2, 0.22, 0.45. '
+             'Only applies to filtration protocols (tangential_flow, syringe).'
     )
 
     parser.add_argument(
@@ -1557,6 +1580,32 @@ Examples:
 
     # Prepare genomes with VLP enrichment
     vlp_protocol = None if args.no_vlp else args.vlp_protocol
+
+    # Handle custom pore size override — map to matching protocol variant
+    if args.pore_size is not None and vlp_protocol is not None:
+        base = vlp_protocol.split('_0')[0]  # Strip existing pore size suffix
+        if base in ('tangential_flow', 'syringe'):
+            pore_map = {0.1: '_01', 0.2: '', 0.22: '', 0.45: '_045'}
+            suffix = pore_map.get(args.pore_size)
+            if suffix is not None:
+                vlp_protocol = base + suffix
+                logger.info(f"Pore size {args.pore_size} μm → protocol: {vlp_protocol}")
+            else:
+                # For non-standard pore sizes, dynamically create a config
+                # and register it in the protocol map
+                from viroforge.enrichment.vlp import VLPProtocol as _VLP
+                custom_config = _VLP.with_custom_pore_size(base, args.pore_size)
+                custom_key = f"{base}_custom"
+                # Monkey-patch: we'll add it to the map inside _apply_vlp_enrichment
+                # by setting vlp_protocol to the custom key and storing the config
+                vlp_protocol = custom_key
+                generator._custom_vlp_configs = getattr(generator, '_custom_vlp_configs', {})
+                generator._custom_vlp_configs[custom_key] = custom_config
+                logger.info(f"Custom pore size: {args.pore_size} μm for {base}")
+        else:
+            logger.warning(f"--pore-size ignored: only applies to tangential_flow or syringe, "
+                         f"not {vlp_protocol}")
+
     use_real = not args.no_real_contaminants
 
     # Build ERV kwargs if any ERV rates are specified

--- a/viroforge/cli/__init__.py
+++ b/viroforge/cli/__init__.py
@@ -119,8 +119,16 @@ For more information: https://github.com/hecatomb/viroforge
     )
     generate_parser.add_argument(
         '--vlp-protocol',
-        choices=['tangential_flow', 'syringe', 'ultracentrifugation', 'norgen'],
-        help='VLP enrichment protocol (default: tangential_flow)'
+        choices=['tangential_flow', 'tangential_flow_045', 'tangential_flow_01',
+                 'syringe', 'syringe_045',
+                 'ultracentrifugation', 'norgen'],
+        help='VLP enrichment protocol (default: tangential_flow). '
+             'Pore sizes: 0.2um (default), _045=0.45um, _01=0.1um'
+    )
+    generate_parser.add_argument(
+        '--pore-size',
+        type=float,
+        help='Custom pore size in um (overrides protocol default)'
     )
     generate_parser.add_argument(
         '--no-vlp',

--- a/viroforge/cli/generate.py
+++ b/viroforge/cli/generate.py
@@ -127,6 +127,8 @@ def generate_with_params(args):
         params['contamination_level'] = args.contamination_level
     if getattr(args, 'vlp_protocol', None):
         params['vlp_protocol'] = args.vlp_protocol
+    if getattr(args, 'pore_size', None):
+        params['pore_size'] = args.pore_size
     if getattr(args, 'no_vlp', False):
         params['no_vlp'] = True
 
@@ -331,6 +333,9 @@ def build_command(script_path: Path, params: Dict) -> List[str]:
         cmd.append('--no-vlp')
     elif 'vlp_protocol' in params:
         cmd.extend(['--vlp-protocol', params['vlp_protocol']])
+
+    if 'pore_size' in params:
+        cmd.extend(['--pore-size', str(params['pore_size'])])
 
     if 'contamination_level' in params:
         cmd.extend(['--contamination-level', params['contamination_level']])

--- a/viroforge/enrichment/vlp.py
+++ b/viroforge/enrichment/vlp.py
@@ -303,6 +303,114 @@ class VLPProtocol:
         )
 
     @classmethod
+    def tangential_flow_045(cls) -> VLPProtocolConfig:
+        """
+        Tangential flow filtration with 0.45 μm pore size.
+
+        Larger pore retains more giant viruses (Mimiviridae, Phycodnaviridae)
+        but allows more bacterial contamination. Used when targeting diverse
+        virome including large dsDNA viruses.
+
+        Reference: Thurber et al. 2009, Castro-Mejia et al. 2015
+        """
+        return VLPProtocolConfig(
+            name="Tangential Flow Filtration (0.45 μm)",
+            filtration_method='tangential_flow',
+            pore_size_um=0.45,
+            prefiltration_pore_size_um=0.80,  # Coarser pre-filter
+            retention_curve_type='sigmoid',
+            retention_curve_steepness=0.006,  # Gentler slope (wider size range)
+            nuclease_treatment=True,
+            nuclease_efficiency=0.98,
+            recovery_rate=0.90,  # Higher recovery (less clogging)
+            contamination_reduction=0.80  # Lower decontamination (larger pore)
+        )
+
+    @classmethod
+    def syringe_filter_045(cls) -> VLPProtocolConfig:
+        """
+        Syringe filtration with 0.45 μm pore size.
+
+        Larger pore, higher throughput, but more bacterial pass-through.
+
+        Reference: Lim et al. 2020
+        """
+        return VLPProtocolConfig(
+            name="Syringe Filter (0.45 μm)",
+            filtration_method='syringe',
+            pore_size_um=0.45,
+            prefiltration_pore_size_um=0.80,
+            retention_curve_type='sigmoid',
+            retention_curve_steepness=0.008,
+            nuclease_treatment=True,
+            nuclease_efficiency=0.90,
+            recovery_rate=0.70,  # Better than 0.2 μm syringe
+            contamination_reduction=0.70  # Lower decontamination
+        )
+
+    @classmethod
+    def tangential_flow_01(cls) -> VLPProtocolConfig:
+        """
+        Tangential flow filtration with 0.1 μm pore size.
+
+        Tighter filtration, excellent decontamination but may lose
+        larger viruses (>200 nm). Good for small phage-dominated viromes.
+
+        Reference: Conceicao-Neto et al. 2015
+        """
+        return VLPProtocolConfig(
+            name="Tangential Flow Filtration (0.1 μm)",
+            filtration_method='tangential_flow',
+            pore_size_um=0.1,
+            prefiltration_pore_size_um=0.22,
+            retention_curve_type='sigmoid',
+            retention_curve_steepness=0.012,  # Steeper (tighter cutoff)
+            nuclease_treatment=True,
+            nuclease_efficiency=0.98,
+            recovery_rate=0.75,  # Lower recovery (more loss)
+            contamination_reduction=0.98  # Excellent decontamination
+        )
+
+    @classmethod
+    def with_custom_pore_size(cls, base_protocol: str, pore_size_um: float) -> VLPProtocolConfig:
+        """
+        Create a protocol with a custom pore size.
+
+        Takes a base protocol and overrides the pore size.
+        Adjusts steepness and contamination reduction accordingly.
+
+        Args:
+            base_protocol: Base protocol name ('tangential_flow' or 'syringe')
+            pore_size_um: Custom pore size in micrometers
+        """
+        if base_protocol == 'tangential_flow':
+            config = cls.tangential_flow_standard()
+        elif base_protocol == 'syringe':
+            config = cls.syringe_filter_standard()
+        else:
+            raise ValueError(f"Custom pore size only applies to filtration protocols, "
+                           f"not '{base_protocol}'")
+
+        config.name = f"{config.filtration_method.replace('_', ' ').title()} ({pore_size_um} μm)"
+        config.pore_size_um = pore_size_um
+
+        # Adjust steepness inversely with pore size (larger pore = gentler slope)
+        config.retention_curve_steepness = 0.008 * (0.2 / pore_size_um)
+
+        # Adjust contamination reduction (larger pore = less decontamination)
+        base_reduction = 0.95 if base_protocol == 'tangential_flow' else 0.85
+        config.contamination_reduction = min(0.99, base_reduction * (0.2 / pore_size_um) ** 0.3)
+
+        # Adjust recovery (larger pore = better recovery)
+        base_recovery = 0.85 if base_protocol == 'tangential_flow' else 0.60
+        config.recovery_rate = min(0.95, base_recovery * (pore_size_um / 0.2) ** 0.15)
+
+        # Adjust pre-filtration (typically 2x the main pore size)
+        config.prefiltration_pore_size_um = min(1.0, pore_size_um * 2)
+
+        return config
+
+    @classmethod
     def no_vlp(cls) -> VLPProtocolConfig:
         """
         No VLP enrichment (bulk metagenome)


### PR DESCRIPTION
## Problem

VLP filtration protocols only support 0.2 um pore size. Real virome studies use different pore sizes depending on the target virome:

- **0.1 um** — Tight filtration, phage-focused, excellent decontamination but loses larger viruses
- **0.2 um** — Standard VLP isolation (most common)
- **0.22 um** — Common variant (essentially same as 0.2)
- **0.45 um** — Larger pore, captures giant viruses (Mimiviridae, Phycodnaviridae) but allows more bacterial contamination

Users cannot currently select or customize the pore size.

## Solution

### New protocol presets

| Protocol | Pore Size | Recovery | Contam Reduction | Use Case |
|---|---|---|---|---|
| tangential_flow | 0.2 um | 85% | 95% | Standard (existing) |
| tangential_flow_045 | 0.45 um | 90% | 80% | Giant viruses |
| tangential_flow_01 | 0.1 um | 75% | 98% | Phage-focused |
| syringe | 0.2 um | 60% | 85% | Standard (existing) |
| syringe_045 | 0.45 um | 70% | 70% | Simple, large pore |

### Custom pore size flag

`--pore-size <um>` overrides the protocol's default pore size with any value. Parameters (steepness, recovery, contamination reduction) are automatically adjusted based on the pore size.

## Usage

```
# Standard 0.2 um (default, unchanged)
--vlp-protocol tangential_flow

# 0.45 um for giant viruses
--vlp-protocol tangential_flow_045

# 0.1 um tight filtration
--vlp-protocol tangential_flow_01

# Any custom pore size
--vlp-protocol tangential_flow --pore-size 0.3
```

Also available via `viroforge generate --vlp-protocol tangential_flow_045` and `--pore-size`.

## Files Changed

- `viroforge/enrichment/vlp.py` — 3 new protocol presets + `with_custom_pore_size()` factory
- `scripts/generate_fastq_dataset.py` — Updated protocol map, CLI flags, custom pore size handling
- `viroforge/cli/__init__.py` — Updated choices, added --pore-size
- `viroforge/cli/generate.py` — Parameter capture and passthrough
