### PR TITLE
docs: document vaginal collection proxy phage limitation and CST gap

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -395,6 +395,23 @@ sqlite3 viroforge/data/viral_genomes.db \
   Illumina spike-in control. Including it as a natural virus causes QC tools
   that remove PhiX to also remove "natural" community reads.
 
+**Vaginal Virome: Proxy Phages from Dairy/Food Lactobacillus (2026-06-02)**
+- The vaginal virome collection (Collection 16) uses Lactobacillus phages from
+  RefSeq as proxies for vaginal Lactobacillus phages. However, nearly all 60
+  Lactobacillus phages in RefSeq infect dairy/food species (L. plantarum,
+  L. delbrueckii, L. casei), not vaginal species (L. crispatus, L. iners,
+  L. gasseri, L. jensenii).
+- Only ~1 phage (Lv-1, infecting L. jensenii) is from a vaginal isolate.
+- No Gardnerella, Prevotella, Atopobium, or Sneathia phages exist in RefSeq,
+  preventing accurate modeling of CST IV (bacterial vaginosis) communities.
+- Impact: The vaginal virome is biologically plausible at the family level
+  (Lactobacillus phages dominate, HPV present) but not species-specific.
+  Benchmarking results for vaginal datasets should note this limitation.
+- CST (Community State Type) modeling is deferred until vaginal-specific
+  phage genomes become available in public databases (RefSeq, INPHARED, GPD).
+- Reference: Lv-1 vaginal phage (Lactobacillus jensenii) described in
+  Miller-Ensminger et al. 2020 (PLOS One, PMC7289420).
+
 ---
 
 ## Recent Bug Fixes (2025-11-16)

--- a/docs/COLLECTION_IMPLEMENTATION_GUIDE.md
+++ b/docs/COLLECTION_IMPLEMENTATION_GUIDE.md
@@ -969,6 +969,16 @@ The vaginal virome is an understudied but clinically important microbial communi
 - **Herpesviruses**: Moderate prevalence (HSV-1, HSV-2, CMV, EBV)
 - **Lactobacillus phages**: Reflect dominance of vaginal Lactobacillus (L. crispatus, L. iners, L. jensenii, L. gasseri)
 
+> **Known Limitation — Proxy Phages**: The Lactobacillus phages in this
+> collection are from RefSeq and mostly originate from dairy/food species
+> (L. plantarum, L. delbrueckii, L. casei), not vaginal species. Only ~1
+> phage (Lv-1) is from a vaginal L. jensenii isolate. No L. crispatus or
+> L. iners phages exist in RefSeq. No Gardnerella/Prevotella phages are
+> available, preventing CST IV (BV) virome modeling. The collection is
+> biologically plausible at the family level but not species-specific.
+> CST support is deferred until vaginal-specific phage genomes become
+> available in public databases.
+
 ### Implementation Details
 
 **Genome Selection**:

--- a/scripts/curate_vaginal_virome_collection.py
+++ b/scripts/curate_vaginal_virome_collection.py
@@ -14,6 +14,21 @@ Represents DNA virome of healthy vaginal microbiome (cervicovaginal samples).
 Bacteriophages dominate (~80% of reads), Lactobacillus phages reflect dominance
 of vaginal Lactobacillus (L. crispatus, L. iners, L. jensenii, L. gasseri).
 
+KNOWN LIMITATION - Proxy Phages:
+  The Lactobacillus phages used in this collection are from RefSeq and mostly
+  originate from dairy/food Lactobacillus species (L. plantarum, L. delbrueckii,
+  L. casei), NOT from vaginal Lactobacillus species. Only ~1 phage (Lv-1) is
+  from a vaginal L. jensenii isolate. No L. crispatus, L. iners, or L. gasseri
+  phages are available in RefSeq. No Gardnerella or Prevotella phages exist
+  in RefSeq, preventing CST IV (BV/dysbiotic) virome modeling.
+
+  The collection is biologically plausible at the family level (Lactobacillus
+  phages dominate healthy vaginal viromes) but not species-specific. Users
+  should note this when interpreting benchmarking results.
+
+  CST (Community State Type) support is planned for when vaginal-specific
+  phage genomes become available in public databases.
+
 Literature basis:
 - Wylie et al. 2014 (BMC Biol): Metagenomic analysis of dsDNA viruses
 - Dols et al. 2016: Vaginal virome and bacterial vaginosis


### PR DESCRIPTION
## Summary

- Documents that the vaginal virome collection (Collection 16) uses proxy Lactobacillus phages from dairy/food species, not vaginal isolates
- Only ~1 of 60 Lactobacillus phages in RefSeq (Lv-1, L. jensenii) is from a vaginal isolate
- No L. crispatus, L. iners, or L. gasseri phages available in RefSeq
- No Gardnerella/Prevotella/Atopobium phages available, preventing CST IV (BV) modeling
- CST implementation deferred until vaginal-specific phage genomes become available

## Test plan

- [ ] Documentation review only, no code changes

Generated with [Claude Code](https://claude.com/claude-code)