### PR TITLE
feat: populate host_associations table (5,957 phage-host mappings)

### DIFF
--- a/docs/DATABASE_FIX_ORDER.md
+++ b/docs/DATABASE_FIX_ORDER.md
@@ -1,0 +1,78 @@
+# Database Fix Scripts — Execution Order
+
+## Overview
+
+The ViroForge database (`viral_genomes.db`) is not tracked in git due to its size (~500 MB). Several fix scripts must be run **in order** after building or updating the database to correct genome curation issues.
+
+These scripts are idempotent — running them multiple times is safe and produces the same result.
+
+## Required Execution Order
+
+**Run these in sequence. Each step depends on the previous one.**
+
+### Step 1: Populate host_associations table
+
+**PR #51** — `feat/populate-host-associations`
+
+```bash
+python scripts/populate_host_associations.py
+```
+
+- **What it does**: Parses host bacterium genus from 6,070 phage genome names and populates the `host_associations` table (previously empty — 0 rows)
+- **Why it must be first**: Steps 2 and 3 rely on host association data to find correct replacement genomes. The `body_site_filter` in `curate_body_site_collections.py` also depends on this table.
+- **Result**: 5,957 phage-host mappings with body site annotations (gut, oral, skin, respiratory, vaginal, marine, soil, etc.)
+- **Verification**: `sqlite3 viroforge/data/viral_genomes.db "SELECT COUNT(*) FROM host_associations"` → should show 5957
+
+### Step 2: Remove animal/plant viruses from human collections
+
+**PR #41** — `fix/animal-virus-contamination`
+
+```bash
+python scripts/fix_animal_virus_contamination.py --apply
+```
+
+- **What it does**: Removes 108 animal viruses (bat, bovine, porcine, simian adenoviruses; penguin/koala herpesviruses; plant viruses) and PhiX174 from 14 human-associated collections. Replaces 82 with correct human viruses (human adenovirus, HSV, EBV, CMV, human TTV, influenza, SARS-CoV-2, etc.)
+- **Why it must be second**: Uses genome name patterns to find human replacements. Does not depend on host_associations, but should run before Step 3 to avoid replacing animal viruses with wrong phages.
+- **Result**: 0 animal/plant viruses in any human-associated collection
+- **Verification**: `python scripts/fix_animal_virus_contamination.py --dry-run` → should show "Total animal/plant viruses found: 0"
+
+### Step 3: Fix phage host specificity
+
+**PR #50** — `fix/phage-host-specificity`
+
+```bash
+python scripts/fix_phage_host_specificity.py --apply
+```
+
+- **What it does**: Removes 84 non-site-appropriate phages (marine Vibrio phages in gut, plant Ralstonia phages in oral, E. coli phages in skin/vaginal, etc.) and replaces them with body-site-matched phages (Streptococcus phages for oral, Propionibacterium phages for skin, Bacteroides/Faecalibacterium phages for gut, etc.)
+- **Why it must be third**: Depends on Step 2 having already removed animal viruses (to avoid double-counting). Uses host_associations data from Step 1 for some replacement logic.
+- **Result**: 0 non-site-appropriate phages in any collection
+- **Verification**: `python scripts/fix_phage_host_specificity.py --dry-run` → should show "Total: 0 wrong phages removed"
+
+## Quick Copy-Paste
+
+```bash
+# Run all three fixes in order
+python scripts/populate_host_associations.py
+python scripts/fix_animal_virus_contamination.py --apply
+python scripts/fix_phage_host_specificity.py --apply
+
+# Verify all clean
+python scripts/fix_animal_virus_contamination.py --dry-run
+python scripts/fix_phage_host_specificity.py --dry-run
+```
+
+## What These Fix
+
+| Issue | Affected Collections | Examples of Wrong Genomes |
+|---|---|---|
+| Animal viruses in human collections | 14 collections | Bat adenovirus, penguin herpesvirus, chicken anemia virus |
+| PhiX174 lab spike-in as natural virus | 9 collections | GCF_000819615.1 in gut, oral, skin, etc. |
+| Marine phages in human body sites | Gut, Oral, IBD, HIV+ | Vibrio phages (marine bacteria) |
+| Plant phages in human body sites | Gut, Oral, Respiratory | Ralstonia, Xanthomonas phages (plant pathogens) |
+| E. coli phages in non-gut sites | Oral, Skin, Respiratory, Vaginal | Coliphages, Enterobacteria phages |
+| Insect phages in human body sites | Multiple | Spiroplasma phage (insect endosymbiont) |
+
+## Root Cause Prevention
+
+After running these fixes, the `curate_body_site_collections.py` script has been updated with `body_site_filter` parameters (PR #51) that use the populated `host_associations` table. Future collection rebuilds will automatically select site-appropriate phages.

--- a/scripts/curate_body_site_collections.py
+++ b/scripts/curate_body_site_collections.py
@@ -39,6 +39,7 @@ class TaxonTarget:
     rank: str  # 'family', 'genus', 'species', etc.
     host_filter: Optional[str] = None
     genome_type: Optional[str] = None  # 'dsDNA', 'ssRNA', etc.
+    body_site_filter: Optional[str] = None  # Filter by host_associations.association_type
 
 
 @dataclass
@@ -74,11 +75,11 @@ COLLECTION_SPECS = {
         phage_fraction=0.96,
         composition=[
             TaxonTarget('Crassvirales', 150, 'order'),  # 30%
-            TaxonTarget('Siphoviridae', 140, 'family'),  # 28%
-            TaxonTarget('Myoviridae', 70, 'family'),     # 14%
-            TaxonTarget('Podoviridae', 40, 'family'),    # 8%
-            TaxonTarget('Microviridae', 50, 'family'),   # 10%
-            TaxonTarget('Inoviridae', 15, 'family'),     # 3%
+            TaxonTarget('Siphoviridae', 140, 'family', body_site_filter='gut'),  # 28%
+            TaxonTarget('Myoviridae', 70, 'family', body_site_filter='gut'),     # 14%
+            TaxonTarget('Podoviridae', 40, 'family', body_site_filter='gut'),    # 8%
+            TaxonTarget('Microviridae', 50, 'family', body_site_filter='gut'),   # 10%
+            TaxonTarget('Inoviridae', 15, 'family', body_site_filter='gut'),     # 3%
             TaxonTarget('Adenoviridae', 10, 'family', genome_type='dsDNA'),  # 2%
             TaxonTarget('Anelloviridae', 10, 'family', genome_type='ssDNA'), # 2%
             TaxonTarget('Other', 15, 'any'),  # 3%
@@ -101,11 +102,11 @@ COLLECTION_SPECS = {
         target_size=200,
         phage_fraction=0.925,
         composition=[
-            TaxonTarget('Siphoviridae', 80, 'family'),  # 40%
-            TaxonTarget('Myoviridae', 40, 'family'),    # 20%
-            TaxonTarget('Podoviridae', 30, 'family'),   # 15%
-            TaxonTarget('Microviridae', 20, 'family'),  # 10%
-            TaxonTarget('Inoviridae', 15, 'family'),    # 7.5%
+            TaxonTarget('Siphoviridae', 80, 'family', body_site_filter='oral'),  # 40%
+            TaxonTarget('Myoviridae', 40, 'family', body_site_filter='oral'),    # 20%
+            TaxonTarget('Podoviridae', 30, 'family', body_site_filter='oral'),   # 15%
+            TaxonTarget('Microviridae', 20, 'family', body_site_filter='oral'),  # 10%
+            TaxonTarget('Inoviridae', 15, 'family', body_site_filter='oral'),    # 7.5%
             TaxonTarget('Herpesviridae', 8, 'family', genome_type='dsDNA'),  # 4%
             TaxonTarget('Papillomaviridae', 4, 'family', genome_type='dsDNA'), # 2%
             TaxonTarget('Anelloviridae', 3, 'family', genome_type='ssDNA'),    # 1.5%
@@ -155,10 +156,10 @@ COLLECTION_SPECS = {
         phage_fraction=0.875,
         composition=[
             TaxonTarget('Cutibacterium', 40, 'genus', host_filter='Cutibacterium'),  # 20%
-            TaxonTarget('Siphoviridae', 50, 'family'),  # 25%
-            TaxonTarget('Myoviridae', 30, 'family'),    # 15%
-            TaxonTarget('Podoviridae', 25, 'family'),   # 12.5%
-            TaxonTarget('Microviridae', 20, 'family'),  # 10%
+            TaxonTarget('Siphoviridae', 50, 'family', body_site_filter='respiratory'),  # 25%
+            TaxonTarget('Myoviridae', 30, 'family', body_site_filter='respiratory'),    # 15%
+            TaxonTarget('Podoviridae', 25, 'family', body_site_filter='respiratory'),   # 12.5%
+            TaxonTarget('Microviridae', 20, 'family', body_site_filter='respiratory'),  # 10%
             TaxonTarget('Adenoviridae', 10, 'family', genome_type='dsDNA'),  # 5%
             TaxonTarget('Herpesviridae', 8, 'family', genome_type='dsDNA'),  # 4%
             TaxonTarget('Orthomyxoviridae', 7, 'family', genome_type='ssRNA'), # 3.5%
@@ -253,10 +254,10 @@ COLLECTION_SPECS = {
         phage_fraction=0.90,
         composition=[
             TaxonTarget('Lactobacillus', 45, 'genus', host_filter='Lactobacillus'),  # 30%
-            TaxonTarget('Siphoviridae', 45, 'family'),  # 30%
-            TaxonTarget('Myoviridae', 23, 'family'),    # 15%
-            TaxonTarget('Podoviridae', 15, 'family'),   # 10%
-            TaxonTarget('Microviridae', 7, 'family'),   # 5%
+            TaxonTarget('Siphoviridae', 45, 'family', body_site_filter='gut'),  # 30%
+            TaxonTarget('Myoviridae', 23, 'family', body_site_filter='gut'),    # 15%
+            TaxonTarget('Podoviridae', 15, 'family', body_site_filter='gut'),   # 10%
+            TaxonTarget('Microviridae', 7, 'family', body_site_filter='gut'),   # 5%
             TaxonTarget('Murine_viruses', 15, 'any', host_filter='Mus'),  # 10%
         ],
         abundance_model='log_normal',
@@ -385,7 +386,7 @@ class BodySiteCurator:
             query += " AND g.genome_type = ?"
             params.append(target.genome_type)
 
-        # Add host filter if specified
+        # Add host filter if specified (filter by host genus name)
         if target.host_filter:
             query += """
                 AND EXISTS (
@@ -395,6 +396,17 @@ class BodySiteCurator:
                 )
             """
             params.append(f"%{target.host_filter}%")
+
+        # Add body site filter if specified (filter by association_type from host_associations)
+        if target.body_site_filter:
+            query += """
+                AND EXISTS (
+                    SELECT 1 FROM host_associations h
+                    WHERE h.genome_id = g.genome_id
+                    AND h.association_type LIKE ?
+                )
+            """
+            params.append(f"%{target.body_site_filter}%")
 
         query += " ORDER BY RANDOM()"
 

--- a/scripts/populate_host_associations.py
+++ b/scripts/populate_host_associations.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+Populate the host_associations table by parsing host information from genome names.
+
+Most phage genome names in RefSeq follow the pattern:
+    "{Bacterium} phage {name}" → host_genus = "Bacterium"
+    e.g., "Streptococcus phage Dp-1" → host = "Streptococcus"
+
+This also handles:
+    - "Enterobacteria phage X" → host_genus = "Escherichia" (common synonym)
+    - "Coliphage X" → host_genus = "Escherichia"
+    - "Cyanophage X" → host_genus = "Synechococcus" (or Prochlorococcus)
+    - "MAG: Bacterium phage X" → strips MAG prefix
+
+Usage:
+    python scripts/populate_host_associations.py [--database PATH] [--dry-run]
+"""
+
+import sqlite3
+import re
+import logging
+from pathlib import Path
+from typing import Optional, Tuple
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+
+DB_PATH = Path(__file__).parent.parent / 'viroforge' / 'data' / 'viral_genomes.db'
+
+# Special host name mappings (common names → standard genus)
+HOST_MAPPINGS = {
+    'Enterobacteria': 'Escherichia',
+    'Enterobacterial': 'Escherichia',
+    'Coliphage': 'Escherichia',
+    'Cyanophage': 'Cyanobacteria',  # broad group
+    'Mycobacteriophage': 'Mycobacterium',
+    'Actinophage': 'Streptomyces',
+}
+
+# Body site associations for common host genera
+HOST_BODY_SITES = {
+    # Oral
+    'Streptococcus': 'oral,respiratory,skin',
+    'Actinomyces': 'oral',
+    'Fusobacterium': 'oral',
+    'Porphyromonas': 'oral',
+    'Prevotella': 'oral,vaginal',
+    'Treponema': 'oral',
+    'Veillonella': 'oral',
+    'Neisseria': 'oral,respiratory',
+    'Aggregatibacter': 'oral',
+
+    # Skin
+    'Propionibacterium': 'skin',
+    'Cutibacterium': 'skin',
+    'Staphylococcus': 'skin,nasal,respiratory',
+    'Corynebacterium': 'skin',
+    'Micrococcus': 'skin',
+
+    # Gut
+    'Bacteroides': 'gut',
+    'Faecalibacterium': 'gut',
+    'Escherichia': 'gut',
+    'Klebsiella': 'gut',
+    'Enterococcus': 'gut',
+    'Clostridium': 'gut',
+    'Clostridioides': 'gut',
+    'Lactobacillus': 'gut,vaginal',
+    'Bifidobacterium': 'gut',
+    'Salmonella': 'gut',
+    'Shigella': 'gut',
+    'Campylobacter': 'gut',
+    'Helicobacter': 'gut',
+    'Ruminococcus': 'gut',
+    'Roseburia': 'gut',
+    'Eubacterium': 'gut',
+    'Parabacteroides': 'gut',
+
+    # Respiratory
+    'Pseudomonas': 'respiratory,environmental',
+    'Haemophilus': 'respiratory',
+    'Moraxella': 'respiratory',
+    'Bordetella': 'respiratory',
+    'Burkholderia': 'respiratory',
+    'Acinetobacter': 'respiratory,skin',
+    'Mycobacterium': 'respiratory,environmental',
+    'Legionella': 'respiratory,environmental',
+
+    # Vaginal
+    'Gardnerella': 'vaginal',
+    'Atopobium': 'vaginal',
+    'Sneathia': 'vaginal',
+    'Mobiluncus': 'vaginal',
+
+    # Urinary
+    'Proteus': 'urinary',
+    'Ureaplasma': 'urinary,vaginal',
+    'Mycoplasma': 'urinary,vaginal,respiratory',
+
+    # Environmental
+    'Vibrio': 'marine',
+    'Synechococcus': 'marine,freshwater',
+    'Prochlorococcus': 'marine',
+    'Pelagibacter': 'marine',
+    'Cellulophaga': 'marine',
+    'Roseobacter': 'marine',
+    'Ralstonia': 'plant_soil',
+    'Xanthomonas': 'plant',
+    'Erwinia': 'plant',
+    'Agrobacterium': 'plant_soil',
+    'Rhizobium': 'plant_soil',
+    'Bradyrhizobium': 'soil',
+    'Bacillus': 'soil,environmental',
+    'Streptomyces': 'soil',
+    'Arthrobacter': 'soil',
+    'Rhodococcus': 'soil,environmental',
+    'Caulobacter': 'freshwater',
+    'Bdellovibrio': 'aquatic',
+    'Spiroplasma': 'insect',
+}
+
+
+def parse_host_from_name(genome_name: str) -> Optional[Tuple[str, str]]:
+    """
+    Parse host genus from a phage genome name.
+
+    Returns:
+        Tuple of (host_genus, evidence) or None if not parseable.
+    """
+    name = genome_name.strip()
+
+    # Strip "MAG: " prefix
+    if name.startswith('MAG: '):
+        name = name[5:]
+
+    # Pattern 1: "Coliphage X" → Escherichia
+    if name.startswith('Coliphage ') or name.startswith('coliphage '):
+        return ('Escherichia', 'name_pattern:Coliphage')
+
+    # Pattern 2: "Genome of phage G4 (coliphage)"
+    if 'coliphage' in name.lower():
+        return ('Escherichia', 'name_pattern:coliphage_mention')
+
+    # Pattern 3: "Cyanophage X"
+    if name.startswith('Cyanophage ') or name.startswith('cyanophage '):
+        return ('Cyanobacteria', 'name_pattern:Cyanophage')
+
+    # Pattern 4: "{Genus} phage {name}" — the main pattern
+    # Match: word(s) before "phage"
+    match = re.match(r'^(\w+)\s+phage\b', name, re.IGNORECASE)
+    if match:
+        host_word = match.group(1)
+
+        # Check special mappings
+        if host_word in HOST_MAPPINGS:
+            return (HOST_MAPPINGS[host_word], f'name_pattern:mapped_{host_word}')
+
+        # If it looks like a genus name (capitalized, not a common word)
+        if host_word[0].isupper() and len(host_word) > 3:
+            return (host_word, 'name_pattern:genus_phage')
+
+    # Pattern 5: "Bacteriophage X" — too generic, skip
+    if name.startswith('Bacteriophage '):
+        return None
+
+    # Pattern 6: "{Genus} virus {name}" for some phages
+    match = re.match(r'^(\w+)\s+virus\b', name, re.IGNORECASE)
+    if match:
+        # Only for known bacterial hosts (not eukaryotic viruses)
+        host_word = match.group(1)
+        if host_word in HOST_BODY_SITES:
+            return (host_word, 'name_pattern:genus_virus')
+
+    return None
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(description='Populate host_associations table')
+    parser.add_argument('--database', default=str(DB_PATH))
+    parser.add_argument('--dry-run', action='store_true', default=False)
+    args = parser.parse_args()
+
+    conn = sqlite3.connect(args.database)
+    conn.row_factory = sqlite3.Row
+
+    # Check current state
+    cursor = conn.execute("SELECT COUNT(*) as cnt FROM host_associations")
+    existing = cursor.fetchone()['cnt']
+    logger.info(f"Current host_associations rows: {existing}")
+
+    if existing > 0:
+        logger.info("Table already populated. Use --force to repopulate.")
+        # Don't return — we'll add new ones that aren't there yet
+
+    # Get all genomes
+    cursor = conn.execute("SELECT genome_id, genome_name FROM genomes")
+    genomes = [dict(row) for row in cursor.fetchall()]
+    logger.info(f"Total genomes: {len(genomes)}")
+
+    # Get already-populated genome IDs
+    cursor = conn.execute("SELECT DISTINCT genome_id FROM host_associations")
+    already_done = {row['genome_id'] for row in cursor.fetchall()}
+
+    parsed = 0
+    skipped = 0
+    failed = 0
+    body_site_counts = {}
+
+    for genome in genomes:
+        if genome['genome_id'] in already_done:
+            skipped += 1
+            continue
+
+        result = parse_host_from_name(genome['genome_name'])
+        if result is None:
+            failed += 1
+            continue
+
+        host_genus, evidence = result
+        body_sites = HOST_BODY_SITES.get(host_genus, 'unknown')
+
+        if not args.dry_run:
+            conn.execute("""
+                INSERT INTO host_associations
+                (genome_id, host_genus, host_name, association_type, evidence)
+                VALUES (?, ?, ?, ?, ?)
+            """, (
+                genome['genome_id'],
+                host_genus,
+                host_genus,
+                body_sites,
+                evidence,
+            ))
+
+        parsed += 1
+
+        # Track body site distribution
+        for site in body_sites.split(','):
+            body_site_counts[site] = body_site_counts.get(site, 0) + 1
+
+    if not args.dry_run:
+        conn.commit()
+
+    logger.info(f"{'='*60}")
+    logger.info(f"Results:")
+    logger.info(f"  Parsed and inserted: {parsed}")
+    logger.info(f"  Already in table:    {skipped}")
+    logger.info(f"  Could not parse:     {failed}")
+    logger.info(f"  Total:               {parsed + skipped + failed}")
+    logger.info(f"")
+    logger.info(f"Body site distribution of parsed hosts:")
+    for site, count in sorted(body_site_counts.items(), key=lambda x: -x[1]):
+        logger.info(f"  {site:25s} {count:>5d}")
+
+    conn.close()
+
+    if args.dry_run:
+        print("\n*** DRY RUN — no changes made. Remove --dry-run to populate. ***")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

The `host_associations` table was empty (0 rows), causing the `host_filter` parameter in `TaxonTarget` to silently do nothing. This is the root cause of non-site-appropriate phages being selected for body-site collections.

## What this does

Parses host genus from phage genome names in RefSeq (5,957 of 6,070 phages = 98.1%):
- `"Streptococcus phage X"` → host_genus = Streptococcus, body_site = oral,respiratory
- `"Propionibacterium phage Y"` → host_genus = Propionibacterium, body_site = skin
- `"Bacteroides phage Z"` → host_genus = Bacteroides, body_site = gut
- Handles special cases: Coliphage→Escherichia, Cyanophage→Cyanobacteria, MAG prefix

Maps 50+ host genera to body sites (oral, skin, gut, respiratory, vaginal, marine, soil, etc.)

## Impact

The existing `host_filter` in `TaxonTarget` now works. Future collection curation will automatically select site-appropriate phages.

## Test plan

- [x] Dry run shows 5,957 parseable hosts
- [x] Verified: `host_filter='Streptococcus'` finds 179 oral phages
- [x] Verified: `host_filter='Propionibacterium'` finds 78 skin phages
- [x] Script is idempotent (re-running skips already-populated entries)

Generated with [Claude Code](https://claude.com/claude-code)