### PR TITLE
fix: prevent rare genome loss from abundance floor and artifact injection

### DIFF
--- a/scripts/generate_fastq_dataset.py
+++ b/scripts/generate_fastq_dataset.py
@@ -867,6 +867,21 @@ class FASTQGenerator:
                 )
 
         # Create abundance file for ISS using actual genome IDs
+        # Enforce minimum abundance floor so every genome gets at least a few reads.
+        # Without this, VLP enrichment + amplification bias can reduce rare genomes
+        # to zero abundance, causing ISS to skip them entirely.
+        min_abundance = 1e-6  # Floor: ~1 read per million
+        abundances_arr = np.array(abundances, dtype=float)
+        below_floor = abundances_arr < min_abundance
+        if np.any(below_floor & (abundances_arr > 0)):
+            n_boosted = int(np.sum(below_floor & (abundances_arr > 0)))
+            abundances_arr[below_floor & (abundances_arr > 0)] = min_abundance
+            # Renormalize to maintain total = 1.0
+            abundances_arr /= abundances_arr.sum()
+            logger.info(f"Applied minimum abundance floor ({min_abundance}) to {n_boosted} "
+                       f"rare genomes to ensure read generation")
+            abundances = list(abundances_arr)
+
         abundance_file = self.metadata_dir / f"{self.collection_name}_abundances.txt"
         with open(abundance_file, 'w') as f:
             for record, abundance in zip(sequences, abundances):

--- a/viroforge/simulators/low_complexity.py
+++ b/viroforge/simulators/low_complexity.py
@@ -275,7 +275,36 @@ def add_low_complexity_reads(
     n_to_modify = int(total_reads * rate)
     read_length = len(r1_records[0].seq) if r1_records else 150
 
-    modify_indices = set(rng.sample(range(total_reads), min(n_to_modify, total_reads)))
+    # Protect rare genomes: identify genomes with very few reads and
+    # exclude their indices from the replacement pool. This prevents
+    # artifact injection from wiping out all reads from rare genomes.
+    min_reads_to_protect = 50  # Genomes with fewer reads are protected
+    genome_read_counts: dict[str, int] = {}
+    genome_read_indices: dict[str, list[int]] = {}
+    for i, r1 in enumerate(r1_records):
+        # Parse genome ID from ISS header: @{genome_id}_{index}_{pair}
+        read_id = r1.id
+        parts = read_id.rsplit('_', 2)
+        genome_id = parts[0] if len(parts) >= 3 else read_id
+        genome_read_counts[genome_id] = genome_read_counts.get(genome_id, 0) + 1
+        if genome_id not in genome_read_indices:
+            genome_read_indices[genome_id] = []
+        genome_read_indices[genome_id].append(i)
+
+    protected_indices = set()
+    for genome_id, count in genome_read_counts.items():
+        if count < min_reads_to_protect:
+            protected_indices.update(genome_read_indices[genome_id])
+
+    # Sample from non-protected indices only
+    eligible_indices = [i for i in range(total_reads) if i not in protected_indices]
+    n_to_modify = min(n_to_modify, len(eligible_indices))
+    modify_indices = set(rng.sample(eligible_indices, n_to_modify))
+
+    if protected_indices:
+        n_protected_genomes = sum(1 for g, c in genome_read_counts.items() if c < min_reads_to_protect)
+        logger.info(f"Protected {len(protected_indices)} reads from {n_protected_genomes} "
+                   f"rare genomes (<{min_reads_to_protect} reads each)")
 
     modified_r1 = []
     modified_r2 = []


### PR DESCRIPTION
## Problem

When VLP enrichment + amplification bias are applied, rare genomes can have their abundances reduced to zero. ISS generates zero reads for zero-abundance genomes, meaning some collection genomes are completely absent from the output FASTQ.

Additionally, the low-complexity artifact injector randomly selects reads to replace. For genomes with very few reads (<50), there's a chance all their reads get replaced with artifact sequences.

Observed: IBD collection with 89 genomes only had 81 genomes in the output. 8 rare CrAssphage variants were missing entirely.

## Root Cause

After VLP size-based enrichment + linker amplification GC bias, some rare genomes (already <0.01% abundance) get reduced to 0.00000000 abundance. ISS generates reads proportional to abundance, so zero = zero reads.

## Fix

### 1. Minimum abundance floor (generate_fastq_dataset.py)

Enforces a floor of 1e-6 on all non-zero abundances before writing the ISS abundance file. With ~700K total reads, this gives ~1 read per genome. Abundances are renormalized after floor application.

### 2. Rare genome protection (low_complexity.py)

Before selecting reads for low-complexity replacement, counts reads per genome. Genomes with fewer than 50 reads have their indices excluded from the replacement pool. The same total number of reads are replaced -- just drawn from abundant genomes instead.

## Result

IBD collection: 81/89 -> 89/89 genome coverage with all artifacts applied (adapter 3%, duplicates 10%, low-complexity 0.5%, linker amplification).
